### PR TITLE
Fix Wizard throwing an exception if there is a hidden step that it needs to pass

### DIFF
--- a/packages/forms/src/Components/Wizard.php
+++ b/packages/forms/src/Components/Wizard.php
@@ -50,7 +50,7 @@ class Wizard extends Component
 
                     if (! $component->isSkippable()) {
                         /** @var Step $currentStep */
-                        $currentStep = $component->getChildComponentContainer()->getComponents()[$currentStep];
+                        $currentStep = $component->getChildComponentContainer()->getComponents(withHidden: true)[$currentStep];
 
                         $currentStep->callBeforeValidation();
                         $currentStep->getChildComponentContainer()->validate();


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

For example:
A wizard exists with 5 steps. Visible are the 1st, 2nd, 4th, 5th steps and hidden is the 3rd step. Currently, if you go past the 2nd step, it throws an exception about not finding an array key with the step number 3 (2nd index).

Why?
Indexes at Wizard.php:53 are offset by the hidden step. However, the JS method triggering the event for the next step, has no idea that there is a gap in the indexes. So, naturally, it sends the next step by it's counter, and an error appears.

In the image you can see 1st result is `withHidden: false` (as it is now) and `withHidden: true` (in the PR).
To me, it doesn't seem like it's causing any issues with other wizards.

![image](https://github.com/CreepPork/filament/assets/1590711/3de05a40-6848-4295-9322-f67480831e54)

